### PR TITLE
Add basic tests, with and without search

### DIFF
--- a/tst/basic.tst
+++ b/tst/basic.tst
@@ -13,3 +13,18 @@ gap> Set(GB_SimpleSearch(ps6, [GB_Con.InGroup(6, AlternatingGroup(6)), GB_Con.Se
 [ (), (3,5)(4,6) ]
 gap> Set(GB_SimpleSearch(ps6, [GB_Con.InGroup(6, Group((1,2,3,4,5,6))), GB_Con.InGroup(6, Group((1,2,4,3,5,6))) ]));
 [ () ]
+
+# Trivial intersection of two 'disjoint' C4 x C4 x C4 groups with equal orbits
+# Involves no search
+gap> g1 := Group([(1,2,3,4), (5,6,7,8), (9,10,11,12)]);;
+gap> g2 := Group([(1,2,4,3), (5,6,8,7), (9,10,12,11)]);;
+gap> Set(GB_SimpleSearch(PartitionStack(12),
+>                        [GB_Con.InGroup(12, g1), GB_Con.InGroup(12, g2)]));
+[ () ]
+
+# Trivial intersection of two primitive groups in S_10 that does involve search
+gap> LoadPackage("primgrp", false);;
+gap> Set(GB_SimpleSearch(PartitionStack(10),
+>                        [GB_Con.InGroup(10, PrimitiveGroup(10, 1)),
+>                         GB_Con.InGroup(10, PrimitiveGroup(10, 3))]));
+[ () ]


### PR DESCRIPTION
The first test requires no search, but requires a fair bit of search in BacktrackKit.

The second one involves primitive groups, and does need some search at the moment.