### PR TITLE
Rename coset refiners to be `InCoset-GB` and `InCosetSimple`

### DIFF
--- a/gap/constraints/canonicalconstraints.g
+++ b/gap/constraints/canonicalconstraints.g
@@ -20,7 +20,7 @@ GB_Con.InCosetSimple := function(group, perm)
     end;
 
     r := rec(
-        name := "InGroupSimple",
+        name := "InCosetSimple",
         largest_required_point := Maximum(LargestMovedPoint(group), LargestMovedPoint(perm)),
         largest_moved_point :=  Maximum(LargestMovedPoint(group), LargestMovedPoint(perm)),
         image := {p} -> RightCoset(group, p),
@@ -50,4 +50,9 @@ GB_Con.InCosetSimple := function(group, perm)
         return Objectify(GBRefinerType, r);
     end;
 
-GB_Con.InGroupSimple := {group} -> GB_Con.InCosetSimple(group, ());
+GB_Con.InGroupSimple := function(group)
+    local con;
+    con := GB_Con.InCosetSimple(group, ());
+    con!.name := "InGroupSimple";
+    return con;
+end;

--- a/gap/constraints/simpleconstraints.g
+++ b/gap/constraints/simpleconstraints.g
@@ -61,7 +61,7 @@ fillOrbits := function(pointlist, n)
     orbitalMap := HashMap();
 
     r := rec(
-        name := "InGroup-GB",
+        name := "InCoset-GB",
         largest_required_point := Maximum(LargestMovedPoint(group), LargestMovedPoint(perm)),
         largest_moved_point :=  Maximum(LargestMovedPoint(group), LargestMovedPoint(perm)),
         image := {p} -> RightCoset(group, p),
@@ -123,4 +123,9 @@ fillOrbits := function(pointlist, n)
         return Objectify(GBRefinerType, r);
     end;
 
-GB_Con.InGroup := {group} -> GB_Con.InCoset(group, ());
+GB_Con.InGroup := function(group)
+    local con;
+    con := GB_Con.InCoset(group, ());
+    con!.name := "InGroup-GB";
+    return con;
+end;


### PR DESCRIPTION
I made this as a PR so that you @ChrisJefferson can let me know your opinion on this change. (Perhaps it's an annoying/bad change to make?)

The change means that constraints directly created by the appropriate 'coset' function will have `InCoset` in their name, whereas only those constraints created by the corresponding 'group' function will have `InGroup` in their name.

I'm not actually changing how anything works, and the refiners are still 'the same', so perhaps it did actually make sense for them all to have the same name. (With this PR, you could have the exact same refiner constructed in different ways having different names.)