### PR TITLE
Add a perfect GraphBacktracking refiner for sets of digraphs: `GB_Con.SetDigraphs`

### DIFF
--- a/gap/constraints/digraphs.g
+++ b/gap/constraints/digraphs.g
@@ -1,0 +1,55 @@
+if not IsBound(OnSetsDigraphs) then
+    OnSetsDigraphs := {set, p} -> Set(set, D -> OnDigraphs(D, p));
+fi;
+
+GB_Con.SetDigraphs := function(setL, setR)
+    local setGraphsToGraph;
+
+    setGraphsToGraph := function(ps, set)
+        local n, k, D, offset, anchor, i, v, cols;
+
+        n := PS_Points(ps);
+        k := Length(set);
+        D := EmptyDigraph(IsMutableDigraph, n);
+        DigraphDisjointUnion(Concatenation([D], set, [EmptyDigraph(k)]));
+        cols := Concatenation(
+            ListWithIdenticalEntries(n, 0),
+            ListWithIdenticalEntries(Sum(set, DigraphNrVertices), 1),
+            ListWithIdenticalEntries(k, 2)
+        );
+
+        offset := n;
+        anchor := n + Sum(set, DigraphNrVertices);
+        for i in [1 .. k] do
+          anchor := anchor + 1;
+          for v in DigraphVertices(set[i]) do
+            DigraphAddEdge(D, v + offset, v);
+            DigraphAddEdge(D, v + offset, anchor);
+          od;
+          offset := offset + DigraphNrVertices(set[i]);
+        od;
+
+        return rec(graph := MakeImmutable(D), vertlabels := cols);
+    end;
+
+    return Objectify(
+        GBRefinerType,
+        rec(
+            name := "GB_SetDigraphs",
+            largest_required_point := Maximum(
+                MaximumList(List(setL, DigraphNrVertices), 0),
+                MaximumList(List(setR, DigraphNrVertices), 0)
+            ),
+            constraint := Constraint.Transport(setL, setR, OnSetsDigraphs),
+            refine := rec(
+                initialise := function(ps, buildingRBase)
+                    if buildingRBase then
+                        return setGraphsToGraph(ps, setL);
+                    else
+                        return setGraphsToGraph(ps, setR);
+                    fi;
+                end
+            ),
+        )
+    );
+end;

--- a/read.g
+++ b/read.g
@@ -14,3 +14,4 @@ ReadPackage( "GraphBacktracking", "gap/constraints/simpleconstraints.g");
 ReadPackage( "GraphBacktracking", "gap/constraints/normaliser.g");
 ReadPackage( "GraphBacktracking", "gap/constraints/canonicalconstraints.g");
 ReadPackage( "GraphBacktracking", "gap/constraints/conjugacy.g");
+ReadPackage( "GraphBacktracking", "gap/constraints/digraphs.g");

--- a/tst/basic.tst
+++ b/tst/basic.tst
@@ -37,3 +37,21 @@ gap> IsTrivial(GB_SimpleSearch(PartitionStack(10),
 >                              [GB_Con.InGroup(PrimitiveGroup(10, 1)),
 >                               GB_Con.InGroup(PrimitiveGroup(10, 3))]));
 true
+
+# Set of digraphs: G = TransitiveGroup(6, 4) and o = OrbitalGraphs(G)
+# Warning: currently too slow
+#gap> G := Group([(1,2,3)(4,5,6), (1,4)(2,5)]);
+#gap> o := Set(["&ECA@_OG", "&EQHcQHc", "&EHcQHcQ"], DigraphFromDigraph6String);
+#gap> GB_SimpleSearch(PartitionStack(6), [GB_Con.SetDigraphs(o, o)])
+#> = Normaliser(SymmetricGroup(6), G);
+#true
+#
+# Set of digraphs: cycle digraph on 4 vertices and its reverse
+gap> o := Set([CycleDigraph(4), DigraphReverse(CycleDigraph(4))]);;
+gap> G := Group([(2,4), (1,2)(3,4)]);;
+gap> GB_SimpleSearch(PartitionStack(4), [GB_Con.SetDigraphs(o, o)]) = G;
+true
+gap> p := OnSetsDigraphs(o, (3,4));;
+gap> GB_SimpleSinglePermSearch(PartitionStack(4), [GB_Con.SetDigraphs(o, p)])
+> * (3,4) in G;
+true


### PR DESCRIPTION
This is work towards https://github.com/peal/vole/issues/39

I might also implement a Rust-level refiner for this in Vole, if we think we might want the performance improvement.