### PR TITLE
Update CI config

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,8 +2,9 @@ name: CI
 
 # Trigger the workflow on push or pull request
 on:
-  - push
-  - pull_request
+  workflow_dispatch:
+  pull_request:
+  push:
 
 jobs:
   # The CI test job
@@ -17,10 +18,11 @@ jobs:
       matrix:
         gap-branch:
           - master
+          - stable-4.14
           - stable-4.13
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: gap-actions/setup-gap@v2
         with:
           GAPBRANCH: ${{ matrix.gap-branch }}
@@ -28,7 +30,9 @@ jobs:
           GAP_PKGS_TO_BUILD: "io profiling datastructures json digraphs orb grape"
       - uses: gap-actions/run-pkg-tests@v2
       - uses: gap-actions/process-coverage@v2
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   # The documentation job
   manual:
@@ -38,7 +42,7 @@ jobs:
     if: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: gap-actions/setup-gap@v2
         with:
           GAP_PKGS_TO_BUILD: ''


### PR DESCRIPTION
To keep code coverage working, you'll have to define a `CODECOV_TOKEN`.
This can be done once in the `peal` GitHub org for all repositories
in it at once.